### PR TITLE
Remove selenium deprecation and webdriver dependency

### DIFF
--- a/lib/generators/templates/common/gemfile.tt
+++ b/lib/generators/templates/common/gemfile.tt
@@ -27,9 +27,6 @@ gem 'rubocop-rspec'
 <% end -%>
 gem 'ruby_raider', '~> 0.7.0'
 <%= ERB.new(File.read(File.expand_path('./partials/automation_gems.tt', __dir__))).result(binding).strip! %>
-<% if %w[selenium watir].include? automation -%>
-gem 'webdrivers'
-<% end -%>
 <% if automation == 'sparkling_ios' -%>
 gem 'sparkling_watir'
 <% end -%>

--- a/lib/generators/templates/helpers/browser_helper.tt
+++ b/lib/generators/templates/helpers/browser_helper.tt
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require 'yaml'
-require 'selenium-webdriver'
 require 'watir'
-require 'webdrivers'
 
 module BrowserHelper
 

--- a/lib/generators/templates/helpers/driver_helper.tt
+++ b/lib/generators/templates/helpers/driver_helper.tt
@@ -24,7 +24,7 @@ end
 require 'yaml'
 <% if automation == 'selenium' -%>
 require 'active_support/inflector'
-require 'webdrivers'
+require 'selenium-webdriver'
 <% else -%>
 require 'appium_lib'
 <% end -%>

--- a/lib/generators/templates/helpers/partials/driver_and_options.tt
+++ b/lib/generators/templates/helpers/partials/driver_and_options.tt
@@ -2,7 +2,7 @@
   def create_driver(*opts)
     @config = YAML.load_file('config/config.yml')
     browser = @config['browser'].to_sym
-    Selenium::WebDriver.for(browser, capabilities: browser_options(*opts))
+    Selenium::WebDriver.for(browser, options: browser_options(*opts))
   end
 
   def browser_options(*opts)
@@ -14,9 +14,9 @@
   def create_options(*opts)
     load_browser = @config['browser'].to_s
     browser = load_browser == 'ie' ? load_browser.upcase : load_browser.capitalize
-    caps = "Selenium::WebDriver::#{browser}::Options".constantize.new
-    opts.each { |option| caps.add_argument(option) }
-    caps
+    options = "Selenium::WebDriver::#{browser}::Options".constantize.new
+    opts.each { |option| options.add_argument(option) }
+    options
   end
 
 <% elsif automation == 'cross_platform' -%>

--- a/lib/ruby_raider.rb
+++ b/lib/ruby_raider.rb
@@ -19,7 +19,7 @@ module RubyRaider
     desc 'version', 'It shows the version of Ruby Raider you are currently using'
 
     def version
-      puts 'The Ruby Raider version is 0.7.8, Happy testing!'
+      puts 'The Ruby Raider version is 0.7.9, Happy testing!'
     end
 
     map 'v' => 'version'

--- a/ruby_raider.gemspec
+++ b/ruby_raider.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'ruby_raider'
-  s.version     = '0.7.8'
+  s.version     = '0.7.9'
   s.summary     = 'A gem to make setup and start of UI automation projects easier'
   s.description = 'This gem has everything you need to start working with test automation'
   s.authors     = ['Agustin Pequeno']


### PR DESCRIPTION
This PR removes webdrivers dependency due to selenium 4.11.0 update, and removes the selenium deprecation warning