### PR TITLE
Add support for multiple browser options

### DIFF
--- a/lib/generators/templates/common/config.tt
+++ b/lib/generators/templates/common/config.tt
@@ -1,5 +1,5 @@
 <% if %w[ios android cross_platform].include?(automation) -%>
 <%= ERB.new(File.read(File.expand_path('./partials/mobile_config.tt', __dir__))).result(binding) %>
 <% else -%>
-<%= ERB.new(File.read(File.expand_path('./partials/web_config.tt', __dir__))).result(binding) %>
+<%= ERB.new(File.read(File.expand_path('./partials/web_config.tt', __dir__)), trim_mode: '-').result(binding) %>
 <% end -%>

--- a/lib/generators/templates/common/partials/web_config.tt
+++ b/lib/generators/templates/common/partials/web_config.tt
@@ -1,3 +1,17 @@
 browser: :chrome
 url: 'https://automationteststore.com/'
 
+<%- if automation == 'selenium' -%>
+driver_options:
+  :timeouts:
+    :implicit: 10000 # 10 seconds
+<% end -%>
+
+browser_arguments:
+  :chrome:
+    - no-sandbox
+    - disable-dev-shm-usage
+    - ignore-certificate-errors
+  :firefox:
+    - acceptInsecureCerts
+    - no-sandbox

--- a/lib/generators/templates/helpers/browser_helper.tt
+++ b/lib/generators/templates/helpers/browser_helper.tt
@@ -11,10 +11,12 @@ module BrowserHelper
 
   private
 
+  def config
+    @config ||= YAML.load_file('config/config.yml')
+  end
+
   def create_browser(*args)
-    @config = YAML.load_file('config/config.yml')
-    browser = @config['browser'].to_sym
-    args = args.empty? ? @config['browser_options'] : args
-    @browser = Watir::Browser.new(browser, options: { args: args })
+    args = args.empty? ? config['browser_arguments'][config['browser']] : args
+    Watir::Browser.new(config['browser'], options: { args: args })
   end
 end

--- a/lib/generators/templates/helpers/partials/driver_and_options.tt
+++ b/lib/generators/templates/helpers/partials/driver_and_options.tt
@@ -2,20 +2,24 @@
   def create_driver(*opts)
     @config = YAML.load_file('config/config.yml')
     browser = @config['browser'].to_sym
-    Selenium::WebDriver.for(browser, options: browser_options(*opts))
+    Selenium::WebDriver.for(browser, options: create_webdriver_options(*opts))
   end
 
-  def browser_options(*opts)
-    opts = opts.empty? ? @config['browser_options'] : opts
-    create_options(*opts)
+  def browser_arguments(*opts)
+    opts.empty? ? @config['browser_arguments'][@config['browser']] : opts
+  end
+
+  def driver_options
+    @config['driver_options']
   end
 
   # :reek:FeatureEnvy
-  def create_options(*opts)
+  def create_webdriver_options(*opts)
     load_browser = @config['browser'].to_s
     browser = load_browser == 'ie' ? load_browser.upcase : load_browser.capitalize
     options = "Selenium::WebDriver::#{browser}::Options".constantize.new
-    opts.each { |option| options.add_argument(option) }
+    browser_arguments(*opts).each { |arg| options.add_argument(arg) }
+    driver_options.each { |opt| options.add_option(opt.first, opt.last) }
     options
   end
 

--- a/lib/generators/templates/helpers/spec_helper.tt
+++ b/lib/generators/templates/helpers/spec_helper.tt
@@ -16,8 +16,8 @@ module SpecHelper
       app
     end
 
-    config.after(:each) do
-      example_name = self.class.descendant_filtered_examples.first.description
+    config.after(:each) do |example|
+      example_name = example.description
       app.screenshot.save("allure-results/screenshots/#{example_name}.png")
       AllureHelper.add_screenshot example_name
       app.close

--- a/lib/generators/templates/helpers/spec_helper.tt
+++ b/lib/generators/templates/helpers/spec_helper.tt
@@ -55,8 +55,8 @@ module SpecHelper
     end
     <%- end -%>
 
-    config.after(:each) do
-      example_name = self.class.descendant_filtered_examples.first.description
+    config.after(:each) do |example|
+      example_name = example.description
       <%= ERB.new(File.read(File.expand_path('./partials/screenshot.tt', __dir__)), trim_mode: '-').result(binding).strip! %>
        AllureHelper.add_screenshot example_name
       <%= ERB.new(File.read(File.expand_path('./partials/quit_driver.tt', __dir__)), trim_mode: '-').result(binding).strip! %>


### PR DESCRIPTION
This PR adds support for multiple browser options through the configuration file and for wait support for selenium through the configuration file

It also fixes the lack of use of example on the spec helper for Rspec frameworks

All the credit for the original implementation goes to @KasperTonsgaard  and his great suggestions